### PR TITLE
Added import statements

### DIFF
--- a/Source/Foundation/NSArray+SDExtensions.m
+++ b/Source/Foundation/NSArray+SDExtensions.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSArray+SDExtensions.h"
+#import "SDLog.h"
 
 @implementation NSMutableArray (SDExtensions)
 

--- a/Source/Foundation/NSData+SDExtensions.m
+++ b/Source/Foundation/NSData+SDExtensions.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSData+SDExtensions.h"
+#import "SDLog.h"
 
 @implementation NSData (SDExtensions)
 

--- a/Source/Foundation/NSDictionary+SDExtensions.h
+++ b/Source/Foundation/NSDictionary+SDExtensions.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 typedef id (^SDSectionKeyBlock)(id blockObject);
 

--- a/Source/Foundation/NSDictionary+SDExtensions.m
+++ b/Source/Foundation/NSDictionary+SDExtensions.m
@@ -8,6 +8,7 @@
 
 #import "NSDictionary+SDExtensions.h"
 #import "NSString+SDExtensions.h"
+#import "SDLog.h"
 
 @implementation NSDictionary (SDExtensions)
 

--- a/Source/Foundation/NSLayoutConstraint+SDExtensions.h
+++ b/Source/Foundation/NSLayoutConstraint+SDExtensions.h
@@ -3,7 +3,7 @@
 // Copyright (c) 2014 Walmart. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 
 @interface NSLayoutConstraint(SDExtensions)

--- a/Source/Foundation/NSMutableAttributedString+SDExtensions.h
+++ b/Source/Foundation/NSMutableAttributedString+SDExtensions.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 SetDirection. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface NSMutableAttributedString (SDExtensions)
 

--- a/Source/Foundation/NSString+SDExtensions.h
+++ b/Source/Foundation/NSString+SDExtensions.h
@@ -6,7 +6,7 @@
 //  Copyright 2011 SetDirection. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "ObjectiveCGenerics.h"
 
 GENERICSABLE(NSString)

--- a/Source/Foundation/NSString+SDExtensions.m
+++ b/Source/Foundation/NSString+SDExtensions.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSString+SDExtensions.h"
+#import "NSData+SDExtensions.h"
 
 GENERICSABLE_IMPLEMENTATION(NSString)
 

--- a/Source/Foundation/SDCompletionGroup.h
+++ b/Source/Foundation/SDCompletionGroup.h
@@ -12,6 +12,8 @@
  operation.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface SDCompletionGroup : NSObject
 
 @property (nonatomic, copy) void(^completion)();

--- a/Source/Foundation/SDDataMap.m
+++ b/Source/Foundation/SDDataMap.m
@@ -10,6 +10,7 @@
 #import "SDModelObject.h"
 #import "NSObject+SDExtensions.h"
 #import "objc/runtime.h"
+#import "SDLog.h"
 
 @interface SDObjectProperty : NSObject
 

--- a/Source/Foundation/SDModelObject.m
+++ b/Source/Foundation/SDModelObject.m
@@ -7,6 +7,7 @@
 //
 
 #import "SDModelObject.h"
+#import "NSDictionary+SDExtensions.h"
 
 #pragma mark - SDObjectProperty interface declaration
 

--- a/Source/Foundation/SDPoser.m
+++ b/Source/Foundation/SDPoser.m
@@ -6,6 +6,7 @@
 //
 
 #import "SDPoser.h"
+#import "SDLog.h"
 
 #pragma mark - SDPoser item storage
 

--- a/Source/Foundation/UIDevice+machine.h
+++ b/Source/Foundation/UIDevice+machine.h
@@ -6,7 +6,7 @@
 //  Copyright 2011 SetDirection. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface UIDevice(machine)
 

--- a/Source/Mapping/SDLocationManager.h
+++ b/Source/Mapping/SDLocationManager.h
@@ -6,6 +6,7 @@
 //
 
 #import <CoreLocation/CoreLocation.h>
+#import "SDMacros.h"
 
 typedef NS_ENUM(NSUInteger,SDLocationManagerAuthorizationScheme) {
     SDLocationManagerAuthorizationAlways,

--- a/Source/Mapping/SDLocationManager.m
+++ b/Source/Mapping/SDLocationManager.m
@@ -9,6 +9,8 @@
 
 #import "SDLocationManager.h"
 #import "NSArray+SDExtensions.h"
+#import "UIDevice+machine.h"
+#import "SDLog.h"
 
 #import <objc/message.h>
 

--- a/Source/UI/NSObject+SDExtensions.m
+++ b/Source/UI/NSObject+SDExtensions.m
@@ -6,6 +6,7 @@
 //  Copyright 2011 SetDirection. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
 #import "NSObject+SDExtensions.h"
 
 #import <objc/runtime.h>

--- a/Source/UI/SDAlertView.m
+++ b/Source/UI/SDAlertView.m
@@ -7,6 +7,7 @@
 //
 
 #import "SDAlertView.h"
+#import "UIDevice+machine.h"
 
 @interface SDAlertView () <UIAlertViewDelegate>
 @property (nonatomic, copy) SDAlertViewCompletionBlock completionBlock;

--- a/Source/UI/SDApplication.h
+++ b/Source/UI/SDApplication.h
@@ -6,6 +6,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "NSObject+SDExtensions.h"
 
 @interface SDApplication : UIApplication
 

--- a/Source/UI/SDApplication.m
+++ b/Source/UI/SDApplication.m
@@ -7,6 +7,7 @@
 
 #import "SDApplication.h"
 #import "SDTimer.h"
+#import "NSObject+SDExtensions.h"
 
 #pragma mark - SDWindowAction
 

--- a/Source/UI/SDButton.m
+++ b/Source/UI/SDButton.m
@@ -7,6 +7,7 @@
 //
 
 #import "SDButton.h"
+#import "UIDevice+machine.h"
 
 @implementation SDButton
 

--- a/Source/UI/SDContentAlertView.m
+++ b/Source/UI/SDContentAlertView.m
@@ -9,6 +9,7 @@
 
 #import "SDContentAlertView.h"
 #import "UIDevice+machine.h"
+#import "SDLog.h"
 
 static const CGFloat kSDContentAlertViewWidth = 270.0;
 static const CGFloat kSDContentAlertViewContentMargin = 9;

--- a/Source/UI/SDCreditCardField/SDCCTextField.m
+++ b/Source/UI/SDCreditCardField/SDCCTextField.m
@@ -6,6 +6,7 @@
 //
 
 #import "SDCCTextField.h"
+#import "SDMacros.h"
 
 static NSString* const kSDTextFieldSpaceChar = @"\u200B";
 

--- a/Source/UI/SDCreditCardField/SDCreditCardField.m
+++ b/Source/UI/SDCreditCardField/SDCreditCardField.m
@@ -9,10 +9,9 @@
 //
 
 #import "SDCreditCardField.h"
-
 #import "SDCCTextField.h"
-
 #import <QuartzCore/QuartzCore.h>
+#import "SDMacros.h"
 
 @interface NSString(SDCreditCardField_Security)
 - (NSString*)stringByHidingAllButLastFourDigits;

--- a/Source/UI/SDFormFieldContainer.m
+++ b/Source/UI/SDFormFieldContainer.m
@@ -8,6 +8,7 @@
 //
 
 #import "SDFormFieldContainer.h"
+#import "UIColor+SDExtensions.h"
 
 @implementation SDFormFieldContainer
 

--- a/Source/UI/SDHitButton.m
+++ b/Source/UI/SDHitButton.m
@@ -8,6 +8,7 @@
 //
 
 #import "SDHitButton.h"
+#import "UIView+SDExtensions.h"
 
 @implementation SDHitButton
 

--- a/Source/UI/SDNavigationBarSearchField.m
+++ b/Source/UI/SDNavigationBarSearchField.m
@@ -9,6 +9,8 @@
 #import "SDNavigationBarSearchField.h"
 #import "SDSearchSuggestionsViewController.h"
 #import "SDTouchCaptureView.h"
+#import "UIColor+SDExtensions.h"
+#import "SDMacros.h"
 
 @interface SDNavigationBarSearchField () <UITextFieldDelegate, SDSearchSuggestionsViewControllerDelegate, UIPopoverControllerDelegate>
 

--- a/Source/UI/SDNumberTextField.m
+++ b/Source/UI/SDNumberTextField.m
@@ -6,6 +6,7 @@
 //
 
 #import "SDNumberTextField.h"
+#import "SDMacros.h"
 #import "NSString+SDExtensions.h"
 
 @interface SDTextField()

--- a/Source/UI/SDPaddedLabel.h
+++ b/Source/UI/SDPaddedLabel.h
@@ -3,7 +3,7 @@
 // Copyright (c) 2014 Walmart. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 
 @interface SDPaddedLabel : UIView

--- a/Source/UI/SDPhotoImageView.m
+++ b/Source/UI/SDPhotoImageView.m
@@ -8,6 +8,7 @@
 
 #import "SDPhotoImageView.h"
 #import <QuartzCore/QuartzCore.h>
+#import "SDMacros.h"
 
 @implementation SDPhotoImageView
 {

--- a/Source/UI/SDPickerModalViewController.m
+++ b/Source/UI/SDPickerModalViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "SDPickerModalViewController.h"
+#import "UIDevice+machine.h"
 
 @interface SDPickerModalViewController ()
 

--- a/Source/UI/SDPickerView.h
+++ b/Source/UI/SDPickerView.h
@@ -6,6 +6,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "NSString+SDExtensions.h"
 
 typedef void(^SDPickerViewDateCompletionBlock)(BOOL canceled, NSDate *selectedDate);
 typedef void(^SDPickerViewItemSelectionCompletionBlock)(BOOL canceled, NSInteger selectedItemIndex, NSString *selectedItem);

--- a/Source/UI/SDPickerView.m
+++ b/Source/UI/SDPickerView.m
@@ -9,6 +9,7 @@
 
 #import "SDPickerView.h"
 #import "UIColor+SDExtensions.h"
+#import "SDMacros.h"
 
 typedef NS_ENUM(NSUInteger, SDPickerViewMode)
 {

--- a/Source/UI/SDPullNavigationBar.m
+++ b/Source/UI/SDPullNavigationBar.m
@@ -15,6 +15,7 @@
 #import "UIDevice+machine.h"
 #import "UIColor+SDExtensions.h"
 #import "UIImage+SDExtensions.h"
+#import "NSString+SDExtensions.h"
 
 static const CGFloat kDefaultMenuWidth = 320.0f;
 static const CGFloat kDefaultMenuHeightBuffer = 44.0f;  // Keeps the bottom of the menu from getting too close to the bottom of the screen

--- a/Source/UI/SDPullNavigationBarControlsView.m
+++ b/Source/UI/SDPullNavigationBarControlsView.m
@@ -9,6 +9,7 @@
 //
 
 #import "SDPullNavigationBarControlsView.h"
+#import "UIView+SDExtensions.h"
 
 @implementation SDPullNavigationBarControlsView
 

--- a/Source/UI/SDPullNavigationManager.m
+++ b/Source/UI/SDPullNavigationManager.m
@@ -12,6 +12,8 @@
 #import "NSObject+SDExtensions.h"
 #import "SDPullNavigationBarControlsView.h"
 #import "SDPullNavigationAutomation.h"
+#import "UIViewController+SDExtensions.h"
+#import "UIDevice+machine.h"
 
 @interface SDPullNavigationManager()
 

--- a/Source/UI/SDQuantityEditView/SDQuantityEditView.m
+++ b/Source/UI/SDQuantityEditView/SDQuantityEditView.m
@@ -7,6 +7,7 @@
 
 #import "SDQuantityEditView.h"
 #import "SDQuantityView.h"
+#import "SDMacros.h"
 
 @interface SDQuantityEditView()
 @property (nonatomic, strong) NSLayoutConstraint *editTotalSpaceToTopContraint;

--- a/Source/UI/SDQuantityEditView/SDQuantityEditViewBehavior.h
+++ b/Source/UI/SDQuantityEditView/SDQuantityEditViewBehavior.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "SDAdjustableItem.h"
 
 typedef void (^SDQuantityEditViewBehaviorWillChangeQuantityBlock)(BOOL increment);

--- a/Source/UI/SDQuantityEditView/SDQuantityEditViewBehavior.m
+++ b/Source/UI/SDQuantityEditView/SDQuantityEditViewBehavior.m
@@ -6,6 +6,8 @@
 //
 
 #import "SDQuantityEditViewBehavior.h"
+#import "SDMacros.h"
+#import "SDLog.h"
 
 @implementation NSDecimalNumber (CurrencyExtension)
 

--- a/Source/UI/SDQuantityEditView/UIView+PaintCode.m
+++ b/Source/UI/SDQuantityEditView/UIView+PaintCode.m
@@ -6,6 +6,7 @@
 //
 
 #import "UIView+PaintCode.h"
+#import "UIView+SDExtensions.h"
 
 @implementation UIView(PaintCode)
 

--- a/Source/UI/SDSearchDisplayController.m
+++ b/Source/UI/SDSearchDisplayController.m
@@ -7,6 +7,7 @@
 //
 
 #import "SDSearchDisplayController.h"
+#import "SDLog.h"
 
 @interface SDSearchDisplayController(Private)
 - (void)setup;

--- a/Source/UI/SDSearchSuggestionsViewController.m
+++ b/Source/UI/SDSearchSuggestionsViewController.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 SetDirection. All rights reserved.
 //
 
+#import "SDMacros.h"
 #import "SDSearchSuggestionsViewController.h"
 
 @interface SDSearchSuggestionsViewController ()

--- a/Source/UI/SDSpanParser.m
+++ b/Source/UI/SDSpanParser.m
@@ -6,6 +6,7 @@
 //
 
 #import "SDSpanParser.h"
+#import "NSError+SDExtensions.h"
 
 typedef NS_ENUM(NSUInteger, SRSpanMatchType)
 {

--- a/Source/UI/SDTableViewCommand.h
+++ b/Source/UI/SDTableViewCommand.h
@@ -5,7 +5,7 @@
 //
 
 #import <Foundation/Foundation.h>
-
+#import <UIKit/UIKit.h>
 
 typedef NS_ENUM (NSUInteger, SDTableCommandType)
 {

--- a/Source/UI/SDTableViewSectionController.h
+++ b/Source/UI/SDTableViewSectionController.h
@@ -7,7 +7,7 @@
 //  Copyright (c) 2014 SetDirection. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #define SECTIONCONTROLLER_MAX_HEIGHT MAXFLOAT
 

--- a/Source/UI/SDTableViewSectionController.m
+++ b/Source/UI/SDTableViewSectionController.m
@@ -8,6 +8,7 @@
 //
 
 #import "SDTableViewSectionController.h"
+#import "SDMacros.h"
 
 // Define USES_RESPONDS_TO_SELECTOR_SHORTCUT in your project to have SDTableViewSectionController figure out which methods are actually implemented by
 // sections.  This code, while more "proper' in terms of what is actually implemented, appears to be causing

--- a/Source/UI/SDTextField.m
+++ b/Source/UI/SDTextField.m
@@ -26,6 +26,9 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "SDTextField.h"
+#import "UIDevice+machine.h"
+#import "SDMacros.h"
+#import "UIView+SDExtensions.h"
 
 SDTextFieldValidationBlock SDTextFieldOptionalFieldValidationBlock = ^(SDTextField *textField){ return YES; };
 

--- a/Source/UI/SDTextFieldPicker.h
+++ b/Source/UI/SDTextFieldPicker.h
@@ -7,6 +7,7 @@
 //
 
 #import "SDTextField.h"
+#import "NSString+SDExtensions.h"
 
 @interface SDTextFieldPicker : SDTextField
 

--- a/Source/UI/SDTextFieldPicker.m
+++ b/Source/UI/SDTextFieldPicker.m
@@ -9,6 +9,7 @@
 #import "SDTextFieldPicker.h"
 #import "SDPickerView.h"
 #import "UIDevice+machine.h"
+#import "SDMacros.h"
 
 @interface SDPickerView()
 @property (nonatomic, readonly) UIToolbar *pickerBar;

--- a/Source/UI/SDTouchCaptureView.m
+++ b/Source/UI/SDTouchCaptureView.m
@@ -7,6 +7,7 @@
 //
 
 #import "SDTouchCaptureView.h"
+#import "SDMacros.h"
 
 @interface SDTouchCaptureView ()
 

--- a/Source/UI/UIAlertView+SDExtensions.h
+++ b/Source/UI/UIAlertView+SDExtensions.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-
+#import <UIKit/UIKit.h>
 
 @interface UIAlertView(SDExtensions)
 

--- a/Source/UI/UIImage+SDExtensions.m
+++ b/Source/UI/UIImage+SDExtensions.m
@@ -16,6 +16,8 @@
 #import <float.h>
 #include <tgmath.h>
 
+#import "SDLog.h"
+
 @implementation UIImage (SDExtensions)
 
 + (UIImage *)imageFromView:(UIView *)view

--- a/Source/UI/UITableViewCell+SDExtensions.m
+++ b/Source/UI/UITableViewCell+SDExtensions.m
@@ -7,6 +7,8 @@
 //
 
 #import "UITableViewCell+SDExtensions.h"
+#import "UIView+SDExtensions.h"
+#import "UIDevice+machine.h"
 
 @implementation UITableViewCell (SDExtensions)
 

--- a/Source/UI/UIView+SDExtensions.m
+++ b/Source/UI/UIView+SDExtensions.m
@@ -8,6 +8,7 @@
 
 #import "UIView+SDExtensions.h"
 #import "UIDevice+machine.h"
+#import "SDLog.h"
 
 @implementation UIView (SDExtensions)
 

--- a/Source/WebServices/NSURLCache+SDExtensions.m
+++ b/Source/WebServices/NSURLCache+SDExtensions.m
@@ -6,6 +6,8 @@
 //  Copyright (c) 2012 SetDirection. All rights reserved.
 //
 
+#import <CoreGraphics/CoreGraphics.h>
+
 #import "NSURLCache+SDExtensions.h"
 #import "NSCachedURLResponse+LeakFix.h"
 #import "NSURLRequest+SDExtensions.h"

--- a/Source/WebServices/Reachability.m
+++ b/Source/WebServices/Reachability.m
@@ -27,8 +27,9 @@
 
 @import SystemConfiguration;
 
+#import <Foundation/Foundation.h>
 #import "Reachability.h"
-
+#import "SDLog.h"
 
 NSString *const kSDReachabilityChangedNotification = @"kSDReachabilityChangedNotification";
 

--- a/Source/WebServices/SDImageCache.h
+++ b/Source/WebServices/SDImageCache.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef void (^UIImageViewURLCompletionBlock)(UIImage *image, NSError *error);
 

--- a/Source/WebServices/SDImageCache.m
+++ b/Source/WebServices/SDImageCache.m
@@ -11,6 +11,7 @@
 #import "NSURLCache+SDExtensions.h"
 #import "NSCachedURLResponse+LeakFix.h"
 #import "NSURLRequest+SDExtensions.h"
+#import "SDLog.h"
 
 #import <objc/runtime.h>
 

--- a/Source/WebServices/SDURLConnection.m
+++ b/Source/WebServices/SDURLConnection.m
@@ -10,6 +10,7 @@
 #import "NSString+SDExtensions.h"
 #import "NSCachedURLResponse+LeakFix.h"
 #import "NSURLCache+SDExtensions.h"
+#import "SDLog.h"
 
 #import <libkern/OSAtomic.h>
 

--- a/Source/WebServices/SDWebService+SDProcessingBlocks.m
+++ b/Source/WebServices/SDWebService+SDProcessingBlocks.m
@@ -8,6 +8,8 @@
 
 #import "SDWebService+SDProcessingBlocks.h"
 #import "SDModelObject.h"
+#import "NSData+SDExtensions.h"
+#import "SDLog.h"
 
 @implementation SDWebService (SDProcessingBlocks)
 

--- a/Source/WebServices/SDWebService.m
+++ b/Source/WebServices/SDWebService.m
@@ -13,6 +13,7 @@
 #import "NSData+SDExtensions.h"
 #import "NSURLRequest+SDExtensions.h"
 #import "SDWebServiceMockResponseQueueProvider.h"
+#import "SDLog.h"
 
 NSString *const SDWebServiceError = @"SDWebServiceError";
 

--- a/Source/WebServices/SDWebServiceMockResponseQueueProvider.m
+++ b/Source/WebServices/SDWebServiceMockResponseQueueProvider.m
@@ -7,6 +7,7 @@
 //
 
 #import "SDWebServiceMockResponseQueueProvider.h"
+#import "SDLog.h"
 
 @implementation SDWebServiceMockResponseQueueProvider {
     // always access the mutable array inside of @synchronized(self)

--- a/Source/WebServices/SDWebServiceMockResponseRequestMapping.m
+++ b/Source/WebServices/SDWebServiceMockResponseRequestMapping.m
@@ -7,6 +7,7 @@
 //
 
 #import "SDWebServiceMockResponseRequestMapping.h"
+#import "NSString+SDExtensions.h"
 
 @interface SDWebServiceMockResponseRequestMapping()
 @property (nonatomic,copy,readwrite) NSString *pathPattern;

--- a/Source/WebServices/UIImageView+SDExtensions.m
+++ b/Source/WebServices/UIImageView+SDExtensions.m
@@ -8,6 +8,8 @@
 
 #import "UIImageView+SDExtensions.h"
 #import "SDURLConnection.h"
+#import "NSError+SDExtensions.h"
+#import "SDMacros.h"
 
 #import <objc/runtime.h>
 


### PR DESCRIPTION
Enables compiling without the need to import all, especially when bridging with Swift. Also makes it clear as to where to find custom properties in categories, along with Opt-clicking to their definition.